### PR TITLE
Remove shadow from editor window on scroll

### DIFF
--- a/themes/Atom Material Theme-color-theme.json
+++ b/themes/Atom Material Theme-color-theme.json
@@ -5,6 +5,7 @@
     "activityBar.background": "#20292e",
     "activityBar.dropBackground": "#009688",
     "activityBar.foreground": "#a7b6b8",
+    "scrollbar.shadow": "#263238", 
     "activityBarBadge.background": "#009688",
     "diffEditor.insertedTextBackground": "#00ff001a",
     "diffEditor.removedTextBackground": "#ff00001a",


### PR DESCRIPTION
The editor window had a shadow when scrolling, that was visually very distracting. I've added "scrollbar.shadow": "#263238" to Line 8 which removes it.