### PR TITLE
fix some syntax color issues in JS and scss

### DIFF
--- a/themes/Atom Material Theme-color-theme.json
+++ b/themes/Atom Material Theme-color-theme.json
@@ -275,6 +275,7 @@
         "meta.function-call.generic.python",
         "keyword.other.special-method.ruby",
         "entity.name.type.js",
+        "variable.other.object.property.js",
         "entity.name.section.group-title.ini",
         "support.variable.property.dom.js",
         "support.variable.property.dom.ts",
@@ -315,9 +316,6 @@
         "entity.name.type.module.ts",
         "entity.name.type.module.tsx",
         "support.variable.dom.tsx",
-        "meta.object-literal.key.js",
-        "variable.other.property.js",
-        "variable.other.object.property.js",
         "support.type.graphql"
       ],
       "settings": {
@@ -361,6 +359,7 @@
         "support.type.property-name.css",
         "support.type.property-name.media.css",
         "support.constant.parity.css",
+        "meta.object-literal.key.js",
         "meta.object-literal.key.ts"
       ],
       "settings": {

--- a/themes/Atom Material Theme-color-theme.json
+++ b/themes/Atom Material Theme-color-theme.json
@@ -275,7 +275,6 @@
         "meta.function-call.generic.python",
         "keyword.other.special-method.ruby",
         "entity.name.type.js",
-        "variable.other.object.property.js",
         "entity.name.section.group-title.ini",
         "support.variable.property.dom.js",
         "support.variable.property.dom.ts",
@@ -316,6 +315,9 @@
         "entity.name.type.module.ts",
         "entity.name.type.module.tsx",
         "support.variable.dom.tsx",
+        "meta.object-literal.key.js",
+        "variable.other.property.js",
+        "variable.other.object.property.js",
         "support.type.graphql"
       ],
       "settings": {
@@ -359,7 +361,6 @@
         "support.type.property-name.css",
         "support.type.property-name.media.css",
         "support.constant.parity.css",
-        "meta.object-literal.key.js",
         "meta.object-literal.key.ts"
       ],
       "settings": {

--- a/themes/Atom Material Theme-color-theme.json
+++ b/themes/Atom Material Theme-color-theme.json
@@ -247,7 +247,8 @@
         "storage.modifier.js",
         "storage.modifier.ts",
         "storage.modifier.tsx",
-        "keyword.type.graphql"
+        "keyword.type.graphql",
+        "keyword.other.default"
       ],
       "settings": {
         "foreground": "#C792EA"


### PR DESCRIPTION
scss:
 - `!default` should be purple it's currently white https://github.com/tobiasalthoff/vscode-atom-material-theme/issues/14

Js:
- other var props in js should be yellow they are currently blue
- object literals should be yellow they are currently blue